### PR TITLE
Update win-2019-compile.yml

### DIFF
--- a/.github/workflows/win-2019-compile.yml
+++ b/.github/workflows/win-2019-compile.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install pre-compiled libmicrohttpd Win64
         run: |
-          curl  -Lo libmicrohttpd-latest-w32-bin.zip https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip
+          curl  -Lo libmicrohttpd-latest-w32-bin.zip https://mirror.tochlab.net/pub/gnu/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip
           unzip libmicrohttpd-latest-w32-bin.zip
 
       - name: Install pre-compiled Readline Win64


### PR DESCRIPTION
Updated libmicrohttpd path in workflow, that solved following error:

```
curl: (28) Failed to connect to ftpmirror.gnu.org port 443 after 26289 ms: Timed out
unzip:  cannot find or open libmicrohttpd-latest-w32-bin.zip, libmicrohttpd-latest-w32-bin.zip.zip or libmicrohttpd-latest-w32-bin.zip.ZIP.
Error: Process completed with exit code 9.
```

[History](https://t.me/tondev/110474)